### PR TITLE
Fix stringElement Set function  where its values from stringElement type

### DIFF
--- a/series/series_test.go
+++ b/series/series_test.go
@@ -1489,6 +1489,16 @@ func TestSeries_Set(t *testing.T) {
 			"[A NaN NaN]",
 		},
 		{
+			Floats([]float64{1.2, 2.2, 3.3}),
+			[]bool{true, true, true},
+			New([]interface{}{
+				&floatElement{e: math.NaN(), nan: true},
+				&floatElement{e: 0, nan: true},
+				&stringElement{e: "NaN", nan: true},
+			}, Float, ""),
+			"[NaN NaN NaN]",
+		},
+		{
 			Strings([]string{"A", "B", "C", "K", "D"}),
 			[]bool{false, true, true, false, true},
 			Ints([]string{"1", "2", "3"}),
@@ -1506,7 +1516,18 @@ func TestSeries_Set(t *testing.T) {
 			Ints([]string{"1", "2", "3"}),
 			"[A 1 2 K 3]",
 		},
-
+		{
+			Ints([]int{1, 2, 3, 4, 5}),
+			Bools([]bool{true, true, true, true, true}),
+			Ints([]interface{}{
+				&intElement{e: 0, nan: true},
+				&intElement{e: 0, nan: false},
+				3,
+				3,
+				3,
+			}),
+			"[NaN 0 3 3 3]",
+		},
 		{
 			StringsList([][]string{{"A"}, {"B"}, {"C"}, {"K"}, {"D"}}),
 			[]int{1, 2, 4},

--- a/series/series_test.go
+++ b/series/series_test.go
@@ -1479,6 +1479,16 @@ func TestSeries_Set(t *testing.T) {
 			"[A 1 2 K 3]",
 		},
 		{
+			Strings([]string{"A", "B", "C"}),
+			[]bool{true, true, true},
+			New([]interface{}{
+				"A",
+				stringElement{e: "", nan: true},
+				stringElement{e: "NaN", nan: true},
+			}, String, ""),
+			"[A NaN NaN]",
+		},
+		{
 			Strings([]string{"A", "B", "C", "K", "D"}),
 			[]bool{false, true, true, false, true},
 			Ints([]string{"1", "2", "3"}),

--- a/series/type-float.go
+++ b/series/type-float.go
@@ -47,6 +47,7 @@ func (e *floatElement) Set(value interface{}) {
 		}
 	case Element:
 		e.e = val.Float()
+		e.nan = val.IsNA()
 	default:
 		e.nan = true
 		return

--- a/series/type-string.go
+++ b/series/type-string.go
@@ -43,10 +43,7 @@ func (e *stringElement) Set(value interface{}) {
 		}
 	case Element:
 		e.e = val.String()
-		if e.e == "NaN" {
-			e.nan = true
-			return
-		}
+		e.nan = val.IsNA()
 	default:
 		e.nan = true
 		return

--- a/series/type-string.go
+++ b/series/type-string.go
@@ -43,6 +43,10 @@ func (e *stringElement) Set(value interface{}) {
 		}
 	case Element:
 		e.e = val.String()
+		if e.e == "NaN" {
+			e.nan = true
+			return
+		}
 	default:
 		e.nan = true
 		return


### PR DESCRIPTION
We faced bug when joining two table where one of right table's column type is string and all the value is `NaN`, the original right table column correctly flag the `NaN` records, but after join operation complete the column in result table doesn't correctly flag the records as `NaN`. This happens due to `Set` operation for `stringElement` only set the value for `stringElement` but not `NaN` flag. This PR is to solve this issue