### PR TITLE
Optimize join operation

### DIFF
--- a/dataframe/benchmark_test.go
+++ b/dataframe/benchmark_test.go
@@ -320,7 +320,6 @@ func generateJoinSeries(
 	}
 	rightVals := make([]int, rightRowCount)
 	for i := 0; i < rightRowCount*relationScaleRightToLeft; i++ {
-		// for j := 0; j < relationScaleRightToLeft; j++ {
 		if i >= rightRowCount {
 			break
 		}

--- a/dataframe/benchmark_test.go
+++ b/dataframe/benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/go-gota/gota/dataframe"
 	"github.com/go-gota/gota/series"
@@ -39,6 +40,28 @@ func generateSeries(n, rep int) (data []series.Series) {
 		data = append(data, series.Strings(ss))
 	}
 	return
+}
+
+func generateSeriesRandomType(numOfRows, numOfCols int) (data []series.Series) {
+	rand.Seed(100)
+	colTypes := []series.Type{series.Int, series.Float}
+	cols := make([]series.Series, numOfCols)
+	for i := 0; i < numOfCols; i++ {
+		colIdx := rand.Intn(len(colTypes))
+		colType := colTypes[colIdx]
+		vals := make([]interface{}, numOfRows)
+		for j := 0; j < numOfRows; j++ {
+			var val interface{}
+			if colType == series.Int {
+				val = rand.Intn(100)
+			} else {
+				val = rand.Float64()
+			}
+			vals[j] = val
+		}
+		cols[i] = series.New(vals, colType, "")
+	}
+	return cols
 }
 
 func generateIntsN(n, k int) (data []int) {
@@ -261,6 +284,595 @@ func BenchmarkDataFrame_Elem(b *testing.B) {
 				for k := 0; k < 100000; k++ {
 					test.data.Elem(k, 0)
 				}
+			}
+		})
+	}
+}
+
+type joinColRowOrdering int
+
+const (
+	sorted joinColRowOrdering = iota
+	reversed
+	random
+)
+
+func shuffleSlice(slice []int) {
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(slice), func(i, j int) { slice[i], slice[j] = slice[j], slice[i] })
+}
+
+func generateJoinSeries(
+	colName string,
+	leftRowCount,
+	rightRowCount,
+	relationScaleLeftToRight,
+	relationScaleRightToLeft int,
+	joinRowOrdering joinColRowOrdering) (series.Series, series.Series) {
+
+	leftVals := make([]int, leftRowCount)
+	for i := 0; i < leftRowCount*relationScaleLeftToRight; i++ {
+		if i >= leftRowCount {
+			break
+		}
+		val := i / relationScaleLeftToRight
+		leftVals[i] = val + 1
+	}
+	rightVals := make([]int, rightRowCount)
+	for i := 0; i < rightRowCount*relationScaleRightToLeft; i++ {
+		// for j := 0; j < relationScaleRightToLeft; j++ {
+		if i >= rightRowCount {
+			break
+		}
+		val := i / relationScaleRightToLeft
+		if joinRowOrdering == reversed {
+			rightVals[i] = rightRowCount - val
+			continue
+		}
+		rightVals[i] = val + 1
+
+	}
+	if joinRowOrdering == random {
+		shuffleSlice(leftVals)
+		shuffleSlice(rightVals)
+	}
+	leftSeries := series.New(leftVals, series.Int, colName)
+	rightSeries := series.New(rightVals, series.Int, colName)
+
+	return leftSeries, rightSeries
+}
+
+func BenchmarkDataFrame_InnerJoinOptimized(b *testing.B) {
+	table := []struct {
+		name                     string
+		joinRows                 []string
+		leftRowCount             int
+		leftColCount             int
+		rightRowCount            int
+		rightColCount            int
+		joinColOrdering          joinColRowOrdering
+		relationScaleLeftToRight int
+		relationScaleRightToLeft int
+	}{
+		{
+			name:                     "10 rows - 10 rows, 1 to 1 join, 2 rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             10,
+			leftColCount:             4,
+			rightRowCount:            10,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "10 rows - 10 rows, 1 to 2 join, 2 rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             10,
+			leftColCount:             4,
+			rightRowCount:            10,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 2,
+		},
+		{
+			name:                     "50 rows - 50 rows, 1 to 1 join, random",
+			joinRows:                 []string{"join_row"},
+			leftRowCount:             50,
+			leftColCount:             4,
+			rightRowCount:            50,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "50 rows - 50 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             50,
+			leftColCount:             4,
+			rightRowCount:            50,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "100 rows - 100 rows, 1 to 1 join, random",
+			joinRows:                 []string{"join_row"},
+			leftRowCount:             100,
+			leftColCount:             4,
+			rightRowCount:            100,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "300 rows - 300 rows, 1 to 1 join, random",
+			joinRows:                 []string{"join_row"},
+			leftRowCount:             300,
+			leftColCount:             4,
+			rightRowCount:            300,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "300 rows - 300 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             300,
+			leftColCount:             4,
+			rightRowCount:            300,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "900 rows - 900 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             900,
+			leftColCount:             4,
+			rightRowCount:            900,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "1000 rows - 1000 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             1000,
+			leftColCount:             4,
+			rightRowCount:            1000,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+	}
+	for _, t := range table {
+		b.StopTimer()
+		leftCols := generateSeriesRandomType(t.leftRowCount, t.leftColCount)
+		rightCols := generateSeriesRandomType(t.rightRowCount, t.rightColCount)
+
+		for _, joinKey := range t.joinRows {
+			leftJoinSeries, rightJoinSeries := generateJoinSeries(joinKey, t.leftRowCount, t.rightRowCount, t.relationScaleLeftToRight, t.relationScaleRightToLeft, t.joinColOrdering)
+			leftCols = append(leftCols, leftJoinSeries)
+			rightCols = append(rightCols, rightJoinSeries)
+		}
+		leftTbl := dataframe.New(leftCols...)
+		rightTbl := dataframe.New(rightCols...)
+
+		b.StartTimer()
+		b.Run(t.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = leftTbl.InnerJoin(rightTbl, t.joinRows...)
+			}
+		})
+	}
+}
+
+func BenchmarkDataFrame_LeftJoinOptimized(b *testing.B) {
+	table := []struct {
+		name                     string
+		joinRows                 []string
+		leftRowCount             int
+		leftColCount             int
+		rightRowCount            int
+		rightColCount            int
+		joinColOrdering          joinColRowOrdering
+		relationScaleLeftToRight int
+		relationScaleRightToLeft int
+	}{
+		{
+			name:                     "10 rows - 10 rows, 1 to 1 join, 2 rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             10,
+			leftColCount:             4,
+			rightRowCount:            10,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "10 rows - 10 rows, 1 to 2 join, 2 rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             10,
+			leftColCount:             4,
+			rightRowCount:            10,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 2,
+		},
+		{
+			name:                     "50 rows - 50 rows, 1 to 1 join, random",
+			joinRows:                 []string{"join_row"},
+			leftRowCount:             50,
+			leftColCount:             4,
+			rightRowCount:            50,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "50 rows - 50 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             50,
+			leftColCount:             4,
+			rightRowCount:            50,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "100 rows - 100 rows, 1 to 1 join, random",
+			joinRows:                 []string{"join_row"},
+			leftRowCount:             100,
+			leftColCount:             4,
+			rightRowCount:            100,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "300 rows - 300 rows, 1 to 1 join, random",
+			joinRows:                 []string{"join_row"},
+			leftRowCount:             300,
+			leftColCount:             4,
+			rightRowCount:            300,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "300 rows - 300 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             300,
+			leftColCount:             4,
+			rightRowCount:            300,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "900 rows - 900 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             900,
+			leftColCount:             4,
+			rightRowCount:            900,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "1000 rows - 1000 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             1000,
+			leftColCount:             4,
+			rightRowCount:            1000,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+	}
+	for _, t := range table {
+		b.StopTimer()
+		leftCols := generateSeriesRandomType(t.leftRowCount, t.leftColCount)
+		rightCols := generateSeriesRandomType(t.rightRowCount, t.rightColCount)
+
+		for _, joinKey := range t.joinRows {
+			leftJoinSeries, rightJoinSeries := generateJoinSeries(joinKey, t.leftRowCount, t.rightRowCount, t.relationScaleLeftToRight, t.relationScaleRightToLeft, t.joinColOrdering)
+			leftCols = append(leftCols, leftJoinSeries)
+			rightCols = append(rightCols, rightJoinSeries)
+		}
+		leftTbl := dataframe.New(leftCols...)
+		rightTbl := dataframe.New(rightCols...)
+
+		b.StartTimer()
+		b.Run(t.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = leftTbl.LeftJoin(rightTbl, t.joinRows...)
+			}
+		})
+	}
+}
+
+func BenchmarkDataFrame_RightJoinOptimized(b *testing.B) {
+	table := []struct {
+		name                     string
+		joinRows                 []string
+		leftRowCount             int
+		leftColCount             int
+		rightRowCount            int
+		rightColCount            int
+		joinColOrdering          joinColRowOrdering
+		relationScaleLeftToRight int
+		relationScaleRightToLeft int
+	}{
+		{
+			name:                     "10 rows - 10 rows, 1 to 1 join, 2 rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             10,
+			leftColCount:             4,
+			rightRowCount:            10,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "10 rows - 10 rows, 1 to 2 join, 2 rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             10,
+			leftColCount:             4,
+			rightRowCount:            10,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 2,
+		},
+		{
+			name:                     "50 rows - 50 rows, 1 to 1 join, random",
+			joinRows:                 []string{"join_row"},
+			leftRowCount:             50,
+			leftColCount:             4,
+			rightRowCount:            50,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "50 rows - 50 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             50,
+			leftColCount:             4,
+			rightRowCount:            50,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "100 rows - 100 rows, 1 to 1 join, random",
+			joinRows:                 []string{"join_row"},
+			leftRowCount:             100,
+			leftColCount:             4,
+			rightRowCount:            100,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "300 rows - 300 rows, 1 to 1 join, random",
+			joinRows:                 []string{"join_row"},
+			leftRowCount:             300,
+			leftColCount:             4,
+			rightRowCount:            300,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "300 rows - 300 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             300,
+			leftColCount:             4,
+			rightRowCount:            300,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "900 rows - 900 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             900,
+			leftColCount:             4,
+			rightRowCount:            900,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "1000 rows - 1000 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             1000,
+			leftColCount:             4,
+			rightRowCount:            1000,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+	}
+	for _, t := range table {
+		b.StopTimer()
+		leftCols := generateSeriesRandomType(t.leftRowCount, t.leftColCount)
+		rightCols := generateSeriesRandomType(t.rightRowCount, t.rightColCount)
+
+		for _, joinKey := range t.joinRows {
+			leftJoinSeries, rightJoinSeries := generateJoinSeries(joinKey, t.leftRowCount, t.rightRowCount, t.relationScaleLeftToRight, t.relationScaleRightToLeft, t.joinColOrdering)
+			leftCols = append(leftCols, leftJoinSeries)
+			rightCols = append(rightCols, rightJoinSeries)
+		}
+		leftTbl := dataframe.New(leftCols...)
+		rightTbl := dataframe.New(rightCols...)
+
+		b.StartTimer()
+		b.Run(t.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = leftTbl.RightJoin(rightTbl, t.joinRows...)
+			}
+		})
+	}
+}
+
+func BenchmarkDataFrame_OuterJoinOptimized(b *testing.B) {
+	table := []struct {
+		name                     string
+		joinRows                 []string
+		leftRowCount             int
+		leftColCount             int
+		rightRowCount            int
+		rightColCount            int
+		joinColOrdering          joinColRowOrdering
+		relationScaleLeftToRight int
+		relationScaleRightToLeft int
+	}{
+		{
+			name:                     "10 rows - 10 rows, 1 to 1 join, 2 rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             10,
+			leftColCount:             4,
+			rightRowCount:            10,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "10 rows - 10 rows, 1 to 2 join, 2 rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             10,
+			leftColCount:             4,
+			rightRowCount:            10,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 2,
+		},
+		{
+			name:                     "50 rows - 50 rows, 1 to 1 join, random",
+			joinRows:                 []string{"join_row"},
+			leftRowCount:             50,
+			leftColCount:             4,
+			rightRowCount:            50,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "50 rows - 50 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             50,
+			leftColCount:             4,
+			rightRowCount:            50,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "100 rows - 100 rows, 1 to 1 join, random",
+			joinRows:                 []string{"join_row"},
+			leftRowCount:             100,
+			leftColCount:             4,
+			rightRowCount:            100,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "300 rows - 300 rows, 1 to 1 join, random",
+			joinRows:                 []string{"join_row"},
+			leftRowCount:             300,
+			leftColCount:             4,
+			rightRowCount:            300,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "300 rows - 300 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             300,
+			leftColCount:             4,
+			rightRowCount:            300,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "900 rows - 900 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             900,
+			leftColCount:             4,
+			rightRowCount:            900,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+		{
+			name:                     "1000 rows - 1000 rows, 1 to 1 join, 2 join rows, random",
+			joinRows:                 []string{"join_row1", "join_row2"},
+			leftRowCount:             1000,
+			leftColCount:             4,
+			rightRowCount:            1000,
+			rightColCount:            12,
+			joinColOrdering:          random,
+			relationScaleLeftToRight: 1,
+			relationScaleRightToLeft: 1,
+		},
+	}
+	for _, t := range table {
+		b.StopTimer()
+		leftCols := generateSeriesRandomType(t.leftRowCount, t.leftColCount)
+		rightCols := generateSeriesRandomType(t.rightRowCount, t.rightColCount)
+
+		for _, joinKey := range t.joinRows {
+			leftJoinSeries, rightJoinSeries := generateJoinSeries(joinKey, t.leftRowCount, t.rightRowCount, t.relationScaleLeftToRight, t.relationScaleRightToLeft, t.joinColOrdering)
+			leftCols = append(leftCols, leftJoinSeries)
+			rightCols = append(rightCols, rightJoinSeries)
+		}
+		leftTbl := dataframe.New(leftCols...)
+		rightTbl := dataframe.New(rightCols...)
+
+		b.StartTimer()
+		b.Run(t.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = leftTbl.OuterJoin(rightTbl, t.joinRows...)
 			}
 		})
 	}

--- a/dataframe/benchmark_test.go
+++ b/dataframe/benchmark_test.go
@@ -341,7 +341,7 @@ func generateJoinSeries(
 	return leftSeries, rightSeries
 }
 
-func BenchmarkDataFrame_InnerJoinOptimized(b *testing.B) {
+func BenchmarkDataFrame_InnerJoin(b *testing.B) {
 	table := []struct {
 		name                     string
 		joinRows                 []string
@@ -475,7 +475,7 @@ func BenchmarkDataFrame_InnerJoinOptimized(b *testing.B) {
 	}
 }
 
-func BenchmarkDataFrame_LeftJoinOptimized(b *testing.B) {
+func BenchmarkDataFrame_LeftJoin(b *testing.B) {
 	table := []struct {
 		name                     string
 		joinRows                 []string
@@ -609,7 +609,7 @@ func BenchmarkDataFrame_LeftJoinOptimized(b *testing.B) {
 	}
 }
 
-func BenchmarkDataFrame_RightJoinOptimized(b *testing.B) {
+func BenchmarkDataFrame_RightJoin(b *testing.B) {
 	table := []struct {
 		name                     string
 		joinRows                 []string
@@ -743,7 +743,7 @@ func BenchmarkDataFrame_RightJoinOptimized(b *testing.B) {
 	}
 }
 
-func BenchmarkDataFrame_OuterJoinOptimized(b *testing.B) {
+func BenchmarkDataFrame_OuterJoin(b *testing.B) {
 	table := []struct {
 		name                     string
 		joinRows                 []string

--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -305,14 +305,14 @@ func (df DataFrame) Subset(indexes series.Indexes) DataFrame {
 
 // SelectIndexes are the supported indexes used for the DataFrame.Select method. Currently supported are:
 //
-//     int              // Matches the given index number
-//     []int            // Matches all given index numbers
-//     []bool           // Matches all columns marked as true
-//     string           // Matches the column with the matching column name
-//     []string         // Matches all columns with the matching column names
-//     Series [Int]     // Same as []int
-//     Series [Bool]    // Same as []bool
-//     Series [String]  // Same as []string
+//	int              // Matches the given index number
+//	[]int            // Matches all given index numbers
+//	[]bool           // Matches all columns marked as true
+//	string           // Matches the column with the matching column name
+//	[]string         // Matches all columns with the matching column names
+//	Series [Int]     // Same as []int
+//	Series [Bool]    // Same as []bool
+//	Series [String]  // Same as []string
 type SelectIndexes interface{}
 
 // Select the given DataFrame columns
@@ -1099,23 +1099,23 @@ func WithComments(b rune) LoadOption {
 //
 // Examples:
 //
-//    // field will be ignored
-//    field int
+//	// field will be ignored
+//	field int
 //
-//    // Field will be ignored
-//    Field int `dataframe:"-"`
+//	// Field will be ignored
+//	Field int `dataframe:"-"`
 //
-//    // Field will be parsed with column name Field and type int
-//    Field int
+//	// Field will be parsed with column name Field and type int
+//	Field int
 //
-//    // Field will be parsed with column name `field_column` and type int.
-//    Field int `dataframe:"field_column"`
+//	// Field will be parsed with column name `field_column` and type int.
+//	Field int `dataframe:"field_column"`
 //
-//    // Field will be parsed with column name `field` and type string.
-//    Field int `dataframe:"field,string"`
+//	// Field will be parsed with column name `field` and type string.
+//	Field int `dataframe:"field,string"`
 //
-//    // Field will be parsed with column name `Field` and type string.
-//    Field int `dataframe:",string"`
+//	// Field will be parsed with column name `Field` and type string.
+//	Field int `dataframe:",string"`
 //
 // If the struct tags and the given LoadOptions contradict each other, the later
 // will have preference over the former.
@@ -1688,76 +1688,55 @@ func (df DataFrame) InnerJoin(b DataFrame, keys ...string) DataFrame {
 	if len(keys) == 0 {
 		return DataFrame{Err: fmt.Errorf("join keys not specified")}
 	}
-	// Check that we have all given keys in both DataFrames
-	var iKeysA []int
-	var iKeysB []int
-	var errorArr []string
-	for _, key := range keys {
-		i := df.colIndex(key)
-		if i < 0 {
-			errorArr = append(errorArr, fmt.Sprintf("can't find key %q on left DataFrame", key))
-		}
-		iKeysA = append(iKeysA, i)
-		j := b.colIndex(key)
-		if j < 0 {
-			errorArr = append(errorArr, fmt.Sprintf("can't find key %q on right DataFrame", key))
-		}
-		iKeysB = append(iKeysB, j)
+
+	props, err := getJoinProperties(df, b, keys...)
+	if err != nil {
+		return DataFrame{Err: err}
 	}
-	if len(errorArr) != 0 {
-		return DataFrame{Err: fmt.Errorf(strings.Join(errorArr, "\n"))}
-	}
+	iKeysA := props.keysAIdx
+	iKeysB := props.keysBIdx
+	iNotKeysA := props.notKeysAIdx
+	iNotKeysB := props.notKeysBIdx
+	newCols := props.newCols
 
 	aCols := df.columns
 	bCols := b.columns
-	// Initialize newCols
-	var newCols []series.Series
-	for _, i := range iKeysA {
-		newCols = append(newCols, aCols[i].Empty())
+
+	bRowIdxLookup := b.createRowIdxLookup(keys, iKeysB)
+	numCols := len(iKeysA) + len(iNotKeysA) + len(iNotKeysB)
+	updatedColRows := make(map[int][]series.Element, numCols)
+	for i := 0; i < numCols; i++ {
+		updatedColRows[i] = make([]series.Element, 0)
 	}
-	var iNotKeysA []int
-	for i := 0; i < df.ncols; i++ {
-		if !inIntSlice(i, iKeysA) {
-			iNotKeysA = append(iNotKeysA, i)
-			newCols = append(newCols, aCols[i].Empty())
+	// Fill newCols
+	for i := 0; i < df.nrows; i++ {
+		rowKey := ""
+		for k := range keys {
+			rowKey = rowKey + aCols[iKeysA[k]].Elem(i).String()
 		}
-	}
-	var iNotKeysB []int
-	for i := 0; i < b.ncols; i++ {
-		if !inIntSlice(i, iKeysB) {
-			iNotKeysB = append(iNotKeysB, i)
-			newCols = append(newCols, bCols[i].Empty())
+		bMatchedRowIdxs := bRowIdxLookup[rowKey]
+		for _, j := range bMatchedRowIdxs {
+			ii := 0
+			for _, k := range iKeysA {
+				elem := aCols[k].Elem(i)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
+				ii++
+			}
+			for _, k := range iNotKeysA {
+				elem := aCols[k].Elem(i)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
+				ii++
+			}
+			for _, k := range iNotKeysB {
+				elem := bCols[k].Elem(j)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
+				ii++
+			}
 		}
 	}
 
-	// Fill newCols
-	for i := 0; i < df.nrows; i++ {
-		for j := 0; j < b.nrows; j++ {
-			match := true
-			for k := range keys {
-				aElem := aCols[iKeysA[k]].Elem(i)
-				bElem := bCols[iKeysB[k]].Elem(j)
-				match = match && aElem.Eq(bElem)
-			}
-			if match {
-				ii := 0
-				for _, k := range iKeysA {
-					elem := aCols[k].Elem(i)
-					newCols[ii].Append(elem)
-					ii++
-				}
-				for _, k := range iNotKeysA {
-					elem := aCols[k].Elem(i)
-					newCols[ii].Append(elem)
-					ii++
-				}
-				for _, k := range iNotKeysB {
-					elem := bCols[k].Elem(j)
-					newCols[ii].Append(elem)
-					ii++
-				}
-			}
-		}
+	for i := 0; i < numCols; i++ {
+		newCols[i].Append(updatedColRows[i])
 	}
 	return New(newCols...)
 }
@@ -1767,97 +1746,74 @@ func (df DataFrame) LeftJoin(b DataFrame, keys ...string) DataFrame {
 	if len(keys) == 0 {
 		return DataFrame{Err: fmt.Errorf("join keys not specified")}
 	}
-	// Check that we have all given keys in both DataFrames
-	var iKeysA []int
-	var iKeysB []int
-	var errorArr []string
-	for _, key := range keys {
-		i := df.colIndex(key)
-		if i < 0 {
-			errorArr = append(errorArr, fmt.Sprintf("can't find key %q on left DataFrame", key))
-		}
-		iKeysA = append(iKeysA, i)
-		j := b.colIndex(key)
-		if j < 0 {
-			errorArr = append(errorArr, fmt.Sprintf("can't find key %q on right DataFrame", key))
-		}
-		iKeysB = append(iKeysB, j)
+	props, err := getJoinProperties(df, b, keys...)
+	if err != nil {
+		return DataFrame{Err: err}
 	}
-	if len(errorArr) != 0 {
-		return DataFrame{Err: fmt.Errorf(strings.Join(errorArr, "\n"))}
-	}
+	iKeysA := props.keysAIdx
+	iKeysB := props.keysBIdx
+	iNotKeysA := props.notKeysAIdx
+	iNotKeysB := props.notKeysBIdx
+	newCols := props.newCols
 
 	aCols := df.columns
 	bCols := b.columns
-	// Initialize newCols
-	var newCols []series.Series
-	for _, i := range iKeysA {
-		newCols = append(newCols, aCols[i].Empty())
-	}
-	var iNotKeysA []int
-	for i := 0; i < df.ncols; i++ {
-		if !inIntSlice(i, iKeysA) {
-			iNotKeysA = append(iNotKeysA, i)
-			newCols = append(newCols, aCols[i].Empty())
-		}
-	}
-	var iNotKeysB []int
-	for i := 0; i < b.ncols; i++ {
-		if !inIntSlice(i, iKeysB) {
-			iNotKeysB = append(iNotKeysB, i)
-			newCols = append(newCols, bCols[i].Empty())
-		}
+	bRowIdxLookup := b.createRowIdxLookup(keys, iKeysB)
+	numCols := len(iKeysA) + len(iNotKeysA) + len(iNotKeysB)
+	updatedColRows := make(map[int][]series.Element, numCols)
+	for i := 0; i < numCols; i++ {
+		updatedColRows[i] = make([]series.Element, 0)
 	}
 
 	// Fill newCols
 	for i := 0; i < df.nrows; i++ {
-		matched := false
-		for j := 0; j < b.nrows; j++ {
-			match := true
-			for k := range keys {
-				aElem := aCols[iKeysA[k]].Elem(i)
-				bElem := bCols[iKeysB[k]].Elem(j)
-				match = match && aElem.Eq(bElem)
-			}
-			if match {
-				matched = true
-				ii := 0
-				for _, k := range iKeysA {
-					elem := aCols[k].Elem(i)
-					newCols[ii].Append(elem)
-					ii++
-				}
-				for _, k := range iNotKeysA {
-					elem := aCols[k].Elem(i)
-					newCols[ii].Append(elem)
-					ii++
-				}
-				for _, k := range iNotKeysB {
-					elem := bCols[k].Elem(j)
-					newCols[ii].Append(elem)
-					ii++
-				}
-			}
+		rowKey := ""
+		for k := range keys {
+			rowKey = rowKey + aCols[iKeysA[k]].Elem(i).String()
 		}
-		if !matched {
+		bMatchedRowIdxs := bRowIdxLookup[rowKey]
+		if len(bMatchedRowIdxs) == 0 {
 			ii := 0
 			for _, k := range iKeysA {
 				elem := aCols[k].Elem(i)
-				newCols[ii].Append(elem)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
 				ii++
 			}
 			for _, k := range iNotKeysA {
 				elem := aCols[k].Elem(i)
-				newCols[ii].Append(elem)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
 				ii++
 			}
 			for range iNotKeysB {
-				newCols[ii].Append(nil)
+				updatedColRows[ii] = append(updatedColRows[ii], nil)
+				ii++
+			}
+			continue
+		}
+
+		for _, j := range bMatchedRowIdxs {
+			ii := 0
+			for _, k := range iKeysA {
+				elem := aCols[k].Elem(i)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
+				ii++
+			}
+			for _, k := range iNotKeysA {
+				elem := aCols[k].Elem(i)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
+				ii++
+			}
+			for _, k := range iNotKeysB {
+				elem := bCols[k].Elem(j)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
 				ii++
 			}
 		}
 	}
 
+	for i := 0; i < numCols; i++ {
+		newCols[i].Append(updatedColRows[i])
+	}
 	return New(newCols...)
 }
 
@@ -1867,106 +1823,88 @@ func (df DataFrame) RightJoin(b DataFrame, keys ...string) DataFrame {
 		return DataFrame{Err: fmt.Errorf("join keys not specified")}
 	}
 	// Check that we have all given keys in both DataFrames
-	var iKeysA []int
-	var iKeysB []int
-	var errorArr []string
-	for _, key := range keys {
-		i := df.colIndex(key)
-		if i < 0 {
-			errorArr = append(errorArr, fmt.Sprintf("can't find key %q on left DataFrame", key))
-		}
-		iKeysA = append(iKeysA, i)
-		j := b.colIndex(key)
-		if j < 0 {
-			errorArr = append(errorArr, fmt.Sprintf("can't find key %q on right DataFrame", key))
-		}
-		iKeysB = append(iKeysB, j)
+	props, err := getJoinProperties(df, b, keys...)
+	if err != nil {
+		return DataFrame{Err: err}
 	}
-	if len(errorArr) != 0 {
-		return DataFrame{Err: fmt.Errorf(strings.Join(errorArr, "\n"))}
-	}
+	iKeysA := props.keysAIdx
+	iKeysB := props.keysBIdx
+	iNotKeysA := props.notKeysAIdx
+	iNotKeysB := props.notKeysBIdx
+	newCols := props.newCols
 
 	aCols := df.columns
 	bCols := b.columns
-	// Initialize newCols
-	var newCols []series.Series
-	for _, i := range iKeysA {
-		newCols = append(newCols, aCols[i].Empty())
+
+	numCols := len(iKeysA) + len(iNotKeysA) + len(iNotKeysB)
+	updatedColRows := make(map[int][]series.Element, numCols)
+	nonMatchedColRows := make(map[int][]series.Element, numCols)
+	for i := 0; i < numCols; i++ {
+		updatedColRows[i] = make([]series.Element, 0)
+		nonMatchedColRows[i] = make([]series.Element, 0)
 	}
-	var iNotKeysA []int
-	for i := 0; i < df.ncols; i++ {
-		if !inIntSlice(i, iKeysA) {
-			iNotKeysA = append(iNotKeysA, i)
-			newCols = append(newCols, aCols[i].Empty())
+
+	aRowIdxLookup := df.createRowIdxLookup(keys, iKeysA)
+	// Fill newCols
+	for j := 0; j < b.nrows; j++ {
+		rowKey := ""
+		for k := range keys {
+			rowKey = rowKey + bCols[iKeysB[k]].Elem(j).String()
 		}
-	}
-	var iNotKeysB []int
-	for i := 0; i < b.ncols; i++ {
-		if !inIntSlice(i, iKeysB) {
-			iNotKeysB = append(iNotKeysB, i)
-			newCols = append(newCols, bCols[i].Empty())
+		aMatchedRowIdxs := aRowIdxLookup[rowKey]
+		if len(aMatchedRowIdxs) == 0 {
+			ii := 0
+			for _, k := range iKeysB {
+				elem := bCols[k].Elem(j)
+				nonMatchedColRows[ii] = append(nonMatchedColRows[ii], elem)
+				ii++
+			}
+			for range iNotKeysA {
+				nonMatchedColRows[ii] = append(nonMatchedColRows[ii], nil)
+				ii++
+			}
+			for _, k := range iNotKeysB {
+				elem := bCols[k].Elem(j)
+				nonMatchedColRows[ii] = append(nonMatchedColRows[ii], elem)
+				ii++
+			}
+			continue
+		}
+		for _, i := range aMatchedRowIdxs {
+			ii := 0
+			for _, k := range iKeysB {
+				elem := bCols[k].Elem(j)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
+				ii++
+			}
+			for _, k := range iNotKeysA {
+				elem := aCols[k].Elem(i)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
+				ii++
+			}
+			for _, k := range iNotKeysB {
+				elem := bCols[k].Elem(j)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
+				ii++
+			}
 		}
 	}
 
-	// Fill newCols
-	var yesmatched []struct{ i, j int }
-	var nonmatched []int
-	for j := 0; j < b.nrows; j++ {
-		matched := false
-		for i := 0; i < df.nrows; i++ {
-			match := true
-			for k := range keys {
-				aElem := aCols[iKeysA[k]].Elem(i)
-				bElem := bCols[iKeysB[k]].Elem(j)
-				match = match && aElem.Eq(bElem)
-			}
-			if match {
-				matched = true
-				yesmatched = append(yesmatched, struct{ i, j int }{i, j})
-			}
+	for i := 0; i < numCols; i++ {
+		if len(nonMatchedColRows) > 0 {
+			updatedColRows[i] = append(updatedColRows[i], nonMatchedColRows[i]...)
 		}
-		if !matched {
-			nonmatched = append(nonmatched, j)
-		}
-	}
-	for _, v := range yesmatched {
-		i := v.i
-		j := v.j
-		ii := 0
-		for _, k := range iKeysA {
-			elem := aCols[k].Elem(i)
-			newCols[ii].Append(elem)
-			ii++
-		}
-		for _, k := range iNotKeysA {
-			elem := aCols[k].Elem(i)
-			newCols[ii].Append(elem)
-			ii++
-		}
-		for _, k := range iNotKeysB {
-			elem := bCols[k].Elem(j)
-			newCols[ii].Append(elem)
-			ii++
-		}
-	}
-	for _, j := range nonmatched {
-		ii := 0
-		for _, k := range iKeysB {
-			elem := bCols[k].Elem(j)
-			newCols[ii].Append(elem)
-			ii++
-		}
-		for range iNotKeysA {
-			newCols[ii].Append(nil)
-			ii++
-		}
-		for _, k := range iNotKeysB {
-			elem := bCols[k].Elem(j)
-			newCols[ii].Append(elem)
-			ii++
-		}
+		newCols[i].Append(updatedColRows[i])
 	}
 	return New(newCols...)
+}
+
+type joinProperty struct {
+	keysAIdx    []int
+	keysBIdx    []int
+	notKeysAIdx []int
+	notKeysBIdx []int
+	newCols     []series.Series
 }
 
 // OuterJoin returns a DataFrame containing the outer join of two DataFrames.
@@ -1975,125 +1913,101 @@ func (df DataFrame) OuterJoin(b DataFrame, keys ...string) DataFrame {
 		return DataFrame{Err: fmt.Errorf("join keys not specified")}
 	}
 	// Check that we have all given keys in both DataFrames
-	var iKeysA []int
-	var iKeysB []int
-	var errorArr []string
-	for _, key := range keys {
-		i := df.colIndex(key)
-		if i < 0 {
-			errorArr = append(errorArr, fmt.Sprintf("can't find key %q on left DataFrame", key))
-		}
-		iKeysA = append(iKeysA, i)
-		j := b.colIndex(key)
-		if j < 0 {
-			errorArr = append(errorArr, fmt.Sprintf("can't find key %q on right DataFrame", key))
-		}
-		iKeysB = append(iKeysB, j)
+	props, err := getJoinProperties(df, b, keys...)
+	if err != nil {
+		return DataFrame{Err: err}
 	}
-	if len(errorArr) != 0 {
-		return DataFrame{Err: fmt.Errorf(strings.Join(errorArr, "\n"))}
-	}
+	iKeysA := props.keysAIdx
+	iKeysB := props.keysBIdx
+	iNotKeysA := props.notKeysAIdx
+	iNotKeysB := props.notKeysBIdx
+	newCols := props.newCols
 
 	aCols := df.columns
 	bCols := b.columns
-	// Initialize newCols
-	var newCols []series.Series
-	for _, i := range iKeysA {
-		newCols = append(newCols, aCols[i].Empty())
-	}
-	var iNotKeysA []int
-	for i := 0; i < df.ncols; i++ {
-		if !inIntSlice(i, iKeysA) {
-			iNotKeysA = append(iNotKeysA, i)
-			newCols = append(newCols, aCols[i].Empty())
-		}
-	}
-	var iNotKeysB []int
-	for i := 0; i < b.ncols; i++ {
-		if !inIntSlice(i, iKeysB) {
-			iNotKeysB = append(iNotKeysB, i)
-			newCols = append(newCols, bCols[i].Empty())
-		}
-	}
+	aRowIdxLookup := df.createRowIdxLookup(keys, iKeysA)
+	bRowIdxLookup := b.createRowIdxLookup(keys, iKeysB)
 
+	numCols := len(iKeysA) + len(iNotKeysA) + len(iNotKeysB)
+	updatedColRows := make(map[int][]series.Element, numCols)
+	for i := 0; i < numCols; i++ {
+		updatedColRows[i] = make([]series.Element, 0)
+	}
 	// Fill newCols
 	for i := 0; i < df.nrows; i++ {
-		matched := false
-		for j := 0; j < b.nrows; j++ {
-			match := true
-			for k := range keys {
-				aElem := aCols[iKeysA[k]].Elem(i)
-				bElem := bCols[iKeysB[k]].Elem(j)
-				match = match && aElem.Eq(bElem)
-			}
-			if match {
-				matched = true
-				ii := 0
-				for _, k := range iKeysA {
-					elem := aCols[k].Elem(i)
-					newCols[ii].Append(elem)
-					ii++
-				}
-				for _, k := range iNotKeysA {
-					elem := aCols[k].Elem(i)
-					newCols[ii].Append(elem)
-					ii++
-				}
-				for _, k := range iNotKeysB {
-					elem := bCols[k].Elem(j)
-					newCols[ii].Append(elem)
-					ii++
-				}
-			}
+		rowKey := ""
+		for k := range keys {
+			rowKey = rowKey + aCols[iKeysA[k]].Elem(i).String()
 		}
-		if !matched {
+		bMatchedRowIdxs := bRowIdxLookup[rowKey]
+		if len(bMatchedRowIdxs) == 0 {
 			ii := 0
 			for _, k := range iKeysA {
 				elem := aCols[k].Elem(i)
-				newCols[ii].Append(elem)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
 				ii++
 			}
 			for _, k := range iNotKeysA {
 				elem := aCols[k].Elem(i)
-				newCols[ii].Append(elem)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
 				ii++
 			}
 			for range iNotKeysB {
-				newCols[ii].Append(nil)
+				updatedColRows[ii] = append(updatedColRows[ii], nil)
 				ii++
 			}
+			continue
 		}
-	}
-	for j := 0; j < b.nrows; j++ {
-		matched := false
-		for i := 0; i < df.nrows; i++ {
-			match := true
-			for k := range keys {
-				aElem := aCols[iKeysA[k]].Elem(i)
-				bElem := bCols[iKeysB[k]].Elem(j)
-				match = match && aElem.Eq(bElem)
-			}
-			if match {
-				matched = true
-			}
-		}
-		if !matched {
+
+		for _, j := range bMatchedRowIdxs {
 			ii := 0
-			for _, k := range iKeysB {
-				elem := bCols[k].Elem(j)
-				newCols[ii].Append(elem)
+			for _, k := range iKeysA {
+				elem := aCols[k].Elem(i)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
 				ii++
 			}
-			for range iNotKeysA {
-				newCols[ii].Append(nil)
+			for _, k := range iNotKeysA {
+				elem := aCols[k].Elem(i)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
 				ii++
 			}
 			for _, k := range iNotKeysB {
 				elem := bCols[k].Elem(j)
-				newCols[ii].Append(elem)
+				updatedColRows[ii] = append(updatedColRows[ii], elem)
 				ii++
 			}
 		}
+	}
+
+	for j := 0; j < b.nrows; j++ {
+		key := make([]string, len(keys))
+		for k := range keys {
+			key[k] = bCols[iKeysB[k]].Elem(j).String()
+		}
+		rowKey := strings.Join(key, "")
+		aMatchedRowIdxs := aRowIdxLookup[rowKey]
+		if len(aMatchedRowIdxs) > 0 {
+			continue
+		}
+		ii := 0
+		for _, k := range iKeysB {
+			elem := bCols[k].Elem(j)
+			updatedColRows[ii] = append(updatedColRows[ii], elem)
+			ii++
+		}
+		for range iNotKeysA {
+			updatedColRows[ii] = append(updatedColRows[ii], nil)
+			ii++
+		}
+		for _, k := range iNotKeysB {
+			elem := bCols[k].Elem(j)
+			updatedColRows[ii] = append(updatedColRows[ii], elem)
+			ii++
+		}
+	}
+
+	for i := 0; i < numCols; i++ {
+		newCols[i].Append(updatedColRows[i])
 	}
 	return New(newCols...)
 }
@@ -2125,6 +2039,74 @@ func (df DataFrame) CrossJoin(b DataFrame) DataFrame {
 		}
 	}
 	return New(newCols...)
+}
+
+func (df DataFrame) createRowIdxLookup(keys []string, keyIdx []int) map[string][]int {
+	cols := df.columns
+	rowIdxLookup := make(map[string][]int)
+	for i := 0; i < df.nrows; i++ {
+		key := make([]string, len(keys))
+		for k := range keys {
+			key[k] = cols[keyIdx[k]].Elem(i).String()
+		}
+		rowKey := strings.Join(key, "")
+		rowIdxLookup[rowKey] = append(rowIdxLookup[rowKey], i)
+	}
+	return rowIdxLookup
+}
+
+func getJoinProperties(a, b DataFrame, keys ...string) (*joinProperty, error) {
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("join keys not specified")
+	}
+	// Check that we have all given keys in both DataFrames
+	var iKeysA []int
+	var iKeysB []int
+	var errorArr []string
+	for _, key := range keys {
+		i := a.colIndex(key)
+		if i < 0 {
+			errorArr = append(errorArr, fmt.Sprintf("can't find key %q on left DataFrame", key))
+		}
+		iKeysA = append(iKeysA, i)
+		j := b.colIndex(key)
+		if j < 0 {
+			errorArr = append(errorArr, fmt.Sprintf("can't find key %q on right DataFrame", key))
+		}
+		iKeysB = append(iKeysB, j)
+	}
+	if len(errorArr) != 0 {
+		return nil, fmt.Errorf(strings.Join(errorArr, "\n"))
+	}
+
+	aCols := a.columns
+	bCols := b.columns
+	// Initialize newCols
+	var newCols []series.Series
+	for _, i := range iKeysA {
+		newCols = append(newCols, aCols[i].Empty())
+	}
+	var iNotKeysA []int
+	for i := 0; i < a.ncols; i++ {
+		if !inIntSlice(i, iKeysA) {
+			iNotKeysA = append(iNotKeysA, i)
+			newCols = append(newCols, aCols[i].Empty())
+		}
+	}
+	var iNotKeysB []int
+	for i := 0; i < b.ncols; i++ {
+		if !inIntSlice(i, iKeysB) {
+			iNotKeysB = append(iNotKeysB, i)
+			newCols = append(newCols, bCols[i].Empty())
+		}
+	}
+	return &joinProperty{
+		keysAIdx:    iKeysA,
+		keysBIdx:    iKeysB,
+		notKeysAIdx: iNotKeysA,
+		notKeysBIdx: iNotKeysB,
+		newCols:     newCols,
+	}, nil
 }
 
 // colIndex returns the index of the column with name `s`. If it fails to find the

--- a/series/series.go
+++ b/series/series.go
@@ -155,11 +155,11 @@ const (
 // Indexes represent the elements that can be used for selecting a subset of
 // elements within a Series. Currently supported are:
 //
-//     int            // Matches the given index number
-//     []int          // Matches all given index numbers
-//     []bool         // Matches all elements in a Series marked as true
-//     Series [Int]   // Same as []int
-//     Series [Bool]  // Same as []bool
+//	int            // Matches the given index number
+//	[]int          // Matches all given index numbers
+//	[]bool         // Matches all elements in a Series marked as true
+//	Series [Int]   // Same as []int
+//	Series [Bool]  // Same as []bool
 type Indexes interface{}
 
 type LogicalOperator int


### PR DESCRIPTION
Previous implementation of join operation using nested strategy, hence it was really slow when joining big table. In this PR we optimize the join operations. The optimization is done by 2 changes:
* Using hash instead of nested algorithm
* Remove repeatedly append series rows which is slow

This optimization applied to
* INNER JOIN
* LEFT JOIN
* RIGHT JOIN
* OUTER JOIN

Below are the benchmark result of the optimization
```
Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^BenchmarkDataFrame_InnerJoin$ github.com/go-gota/gota/dataframe

goos: darwin
goarch: amd64
pkg: github.com/go-gota/gota/dataframe
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkDataFrame_InnerJoin/10_rows_-_10_rows,_1_to_1_join,_2_rows,_random-16         	   87997	     12784 ns/op	   10447 B/op	     118 allocs/op
BenchmarkDataFrame_InnerJoin/10_rows_-_10_rows,_1_to_2_join,_2_rows,_random-16         	   53110	     23191 ns/op	   16789 B/op	     352 allocs/op
BenchmarkDataFrame_InnerJoin/50_rows_-_50_rows,_1_to_1_join,_random-16                 	    6856	    179018 ns/op	  112816 B/op	    2795 allocs/op
BenchmarkDataFrame_InnerJoin/50_rows_-_50_rows,_1_to_1_join,_2_join_rows,_random-16    	   15258	     76330 ns/op	   12177 B/op	     208 allocs/op
BenchmarkDataFrame_InnerJoin/100_rows_-_100_rows,_1_to_1_join,_random-16               	    3033	    413071 ns/op	  217321 B/op	    5362 allocs/op
BenchmarkDataFrame_InnerJoin/300_rows_-_300_rows,_1_to_1_join,_random-16               	     565	   2148514 ns/op	  696389 B/op	   15596 allocs/op
BenchmarkDataFrame_InnerJoin/300_rows_-_300_rows,_1_to_1_join,_2_join_rows,_random-16  	     560	   2236624 ns/op	   14196 B/op	     280 allocs/op
BenchmarkDataFrame_InnerJoin/900_rows_-_900_rows,_1_to_1_join,_2_join_rows,_random-16  	      61	  19667496 ns/op	   10502 B/op	     118 allocs/op
BenchmarkDataFrame_InnerJoin/1000_rows_-_1000_rows,_1_to_1_join,_2_join_rows,_random-16         	      51	  24299993 ns/op	   14201 B/op	     280 allocs/op
PASS
ok  	github.com/go-gota/gota/dataframe	14.046s

Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^BenchmarkDataFrame_InnerJoinOptimized$ github.com/go-gota/gota/dataframe

goos: darwin
goarch: amd64
pkg: github.com/go-gota/gota/dataframe
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkDataFrame_InnerJoinOptimized/10_rows_-_10_rows,_1_to_1_join,_2_rows,_random-16         	   63050	     19157 ns/op	   14673 B/op	     221 allocs/op
BenchmarkDataFrame_InnerJoinOptimized/10_rows_-_10_rows,_1_to_2_join,_2_rows,_random-16         	   63591	     19565 ns/op	   14672 B/op	     219 allocs/op
BenchmarkDataFrame_InnerJoinOptimized/50_rows_-_50_rows,_1_to_1_join,_random-16                 	   13558	     89653 ns/op	   99027 B/op	     521 allocs/op
BenchmarkDataFrame_InnerJoinOptimized/50_rows_-_50_rows,_1_to_1_join,_2_join_rows,_random-16    	   26630	     43406 ns/op	   21845 B/op	     545 allocs/op
BenchmarkDataFrame_InnerJoinOptimized/100_rows_-_100_rows,_1_to_1_join,_random-16               	    7996	    154735 ns/op	  187868 B/op	     742 allocs/op
BenchmarkDataFrame_InnerJoinOptimized/300_rows_-_300_rows,_1_to_1_join,_random-16               	    2434	    428118 ns/op	  599601 B/op	    1671 allocs/op
BenchmarkDataFrame_InnerJoinOptimized/300_rows_-_300_rows,_1_to_1_join,_2_join_rows,_random-16  	    5998	    202443 ns/op	   86856 B/op	    2805 allocs/op
BenchmarkDataFrame_InnerJoinOptimized/900_rows_-_900_rows,_1_to_1_join,_2_join_rows,_random-16  	    1970	    650374 ns/op	  311440 B/op	   10039 allocs/op
BenchmarkDataFrame_InnerJoinOptimized/1000_rows_-_1000_rows,_1_to_1_join,_2_join_rows,_random-16         	    1760	    705337 ns/op	  320824 B/op	   11149 allocs/op
PASS
ok  	github.com/go-gota/gota/dataframe	12.838s


Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^BenchmarkDataFrame_LeftJoin$ github.com/go-gota/gota/dataframe

goos: darwin
goarch: amd64
pkg: github.com/go-gota/gota/dataframe
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkDataFrame_LeftJoin/10_rows_-_10_rows,_1_to_1_join,_2_rows,_random-16         	   28465	     41820 ns/op	   33791 B/op	     766 allocs/op
BenchmarkDataFrame_LeftJoin/10_rows_-_10_rows,_1_to_2_join,_2_rows,_random-16         	   28773	     41945 ns/op	   33791 B/op	     766 allocs/op
BenchmarkDataFrame_LeftJoin/50_rows_-_50_rows,_1_to_1_join,_random-16                 	    5584	    185805 ns/op	  112816 B/op	    2795 allocs/op
BenchmarkDataFrame_LeftJoin/50_rows_-_50_rows,_1_to_1_join,_2_join_rows,_random-16    	    5728	    190079 ns/op	  120820 B/op	    2962 allocs/op
BenchmarkDataFrame_LeftJoin/100_rows_-_100_rows,_1_to_1_join,_random-16               	    2793	    414948 ns/op	  217320 B/op	    5362 allocs/op
BenchmarkDataFrame_LeftJoin/300_rows_-_300_rows,_1_to_1_join,_random-16               	     558	   2221789 ns/op	  696416 B/op	   15596 allocs/op
BenchmarkDataFrame_LeftJoin/300_rows_-_300_rows,_1_to_1_join,_2_join_rows,_random-16  	     408	   2954309 ns/op	  738711 B/op	   16516 allocs/op
BenchmarkDataFrame_LeftJoin/900_rows_-_900_rows,_1_to_1_join,_2_join_rows,_random-16  	      51	  21787678 ns/op	 2251347 B/op	   48954 allocs/op
BenchmarkDataFrame_LeftJoin/1000_rows_-_1000_rows,_1_to_1_join,_2_join_rows,_random-16         	      45	  26583528 ns/op	 2366813 B/op	   54354 allocs/op
PASS
ok  	github.com/go-gota/gota/dataframe	11.982s

Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^BenchmarkDataFrame_LeftJoinOptimized$ github.com/go-gota/gota/dataframe

goos: darwin
goarch: amd64
pkg: github.com/go-gota/gota/dataframe
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkDataFrame_LeftJoinOptimized/10_rows_-_10_rows,_1_to_1_join,_2_rows,_random-16         	   32270	     36523 ns/op	   32253 B/op	     365 allocs/op
BenchmarkDataFrame_LeftJoinOptimized/10_rows_-_10_rows,_1_to_2_join,_2_rows,_random-16         	   31866	     36364 ns/op	   32246 B/op	     363 allocs/op
BenchmarkDataFrame_LeftJoinOptimized/50_rows_-_50_rows,_1_to_1_join,_random-16                 	   12990	     91541 ns/op	   99025 B/op	     521 allocs/op
BenchmarkDataFrame_LeftJoinOptimized/50_rows_-_50_rows,_1_to_1_join,_2_join_rows,_random-16    	   10000	    100047 ns/op	  106872 B/op	     725 allocs/op
BenchmarkDataFrame_LeftJoinOptimized/100_rows_-_100_rows,_1_to_1_join,_random-16               	    7646	    153699 ns/op	  187863 B/op	     742 allocs/op
BenchmarkDataFrame_LeftJoinOptimized/300_rows_-_300_rows,_1_to_1_join,_random-16               	    2722	    427273 ns/op	  599595 B/op	    1671 allocs/op
BenchmarkDataFrame_LeftJoinOptimized/300_rows_-_300_rows,_1_to_1_join,_2_join_rows,_random-16  	    2402	    484306 ns/op	  643338 B/op	    2968 allocs/op
BenchmarkDataFrame_LeftJoinOptimized/900_rows_-_900_rows,_1_to_1_join,_2_join_rows,_random-16  	     820	   1495797 ns/op	 2102538 B/op	   10221 allocs/op
BenchmarkDataFrame_LeftJoinOptimized/1000_rows_-_1000_rows,_1_to_1_join,_2_join_rows,_random-16         	     763	   1596909 ns/op	 2114567 B/op	   11421 allocs/op
PASS
ok  	github.com/go-gota/gota/dataframe	12.640s

Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^BenchmarkDataFrame_RightJoin$ github.com/go-gota/gota/dataframe

goos: darwin
goarch: amd64
pkg: github.com/go-gota/gota/dataframe
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkDataFrame_RightJoin/10_rows_-_10_rows,_1_to_1_join,_2_rows,_random-16         	   27195	     44816 ns/op	   34037 B/op	     771 allocs/op
BenchmarkDataFrame_RightJoin/10_rows_-_10_rows,_1_to_2_join,_2_rows,_random-16         	   27736	     43584 ns/op	   33960 B/op	     772 allocs/op
BenchmarkDataFrame_RightJoin/50_rows_-_50_rows,_1_to_1_join,_random-16                 	    6448	    177320 ns/op	  114848 B/op	    2802 allocs/op
BenchmarkDataFrame_RightJoin/50_rows_-_50_rows,_1_to_1_join,_2_join_rows,_random-16    	    5624	    214659 ns/op	  121856 B/op	    2970 allocs/op
BenchmarkDataFrame_RightJoin/100_rows_-_100_rows,_1_to_1_join,_random-16               	    2798	    438853 ns/op	  221417 B/op	    5370 allocs/op
BenchmarkDataFrame_RightJoin/300_rows_-_300_rows,_1_to_1_join,_random-16               	     543	   2251131 ns/op	  712766 B/op	   15606 allocs/op
BenchmarkDataFrame_RightJoin/300_rows_-_300_rows,_1_to_1_join,_2_join_rows,_random-16  	     399	   3041994 ns/op	  747027 B/op	   16529 allocs/op
BenchmarkDataFrame_RightJoin/900_rows_-_900_rows,_1_to_1_join,_2_join_rows,_random-16  	      55	  22517182 ns/op	 2276722 B/op	   48968 allocs/op
BenchmarkDataFrame_RightJoin/1000_rows_-_1000_rows,_1_to_1_join,_2_join_rows,_random-16         	      44	  27815645 ns/op	 2391833 B/op	   54367 allocs/op
PASS
ok  	github.com/go-gota/gota/dataframe	12.495s

Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^BenchmarkDataFrame_RightJoinOptimized$ github.com/go-gota/gota/dataframe

goos: darwin
goarch: amd64
pkg: github.com/go-gota/gota/dataframe
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkDataFrame_RightJoinOptimized/10_rows_-_10_rows,_1_to_1_join,_2_rows,_random-16         	   28920	     46395 ns/op	   36309 B/op	     384 allocs/op
BenchmarkDataFrame_RightJoinOptimized/10_rows_-_10_rows,_1_to_2_join,_2_rows,_random-16         	   24666	     44219 ns/op	   33709 B/op	     418 allocs/op
BenchmarkDataFrame_RightJoinOptimized/50_rows_-_50_rows,_1_to_1_join,_random-16                 	   13364	     93748 ns/op	  100199 B/op	     522 allocs/op
BenchmarkDataFrame_RightJoinOptimized/50_rows_-_50_rows,_1_to_1_join,_2_join_rows,_random-16    	    9750	    113959 ns/op	  125051 B/op	     780 allocs/op
BenchmarkDataFrame_RightJoinOptimized/100_rows_-_100_rows,_1_to_1_join,_random-16               	    8072	    161817 ns/op	  189040 B/op	     743 allocs/op
BenchmarkDataFrame_RightJoinOptimized/300_rows_-_300_rows,_1_to_1_join,_random-16               	    2612	    457870 ns/op	  600780 B/op	    1672 allocs/op
BenchmarkDataFrame_RightJoinOptimized/300_rows_-_300_rows,_1_to_1_join,_2_join_rows,_random-16  	    1998	    594861 ns/op	  732893 B/op	    3023 allocs/op
BenchmarkDataFrame_RightJoinOptimized/900_rows_-_900_rows,_1_to_1_join,_2_join_rows,_random-16  	     685	   1778235 ns/op	 2400032 B/op	   10276 allocs/op
BenchmarkDataFrame_RightJoinOptimized/1000_rows_-_1000_rows,_1_to_1_join,_2_join_rows,_random-16         	     649	   1864717 ns/op	 2411449 B/op	   11458 allocs/op
PASS
ok  	github.com/go-gota/gota/dataframe	13.283s

Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^BenchmarkDataFrame_OuterJoin$ github.com/go-gota/gota/dataframe

goos: darwin
goarch: amd64
pkg: github.com/go-gota/gota/dataframe
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkDataFrame_OuterJoin/10_rows_-_10_rows,_1_to_1_join,_2_rows,_random-16         	   16772	     71002 ns/op	   57423 B/op	    1324 allocs/op
BenchmarkDataFrame_OuterJoin/10_rows_-_10_rows,_1_to_2_join,_2_rows,_random-16         	   17258	     69843 ns/op	   57425 B/op	    1324 allocs/op
BenchmarkDataFrame_OuterJoin/50_rows_-_50_rows,_1_to_1_join,_random-16                 	    5617	    239613 ns/op	  112816 B/op	    2795 allocs/op
BenchmarkDataFrame_OuterJoin/50_rows_-_50_rows,_1_to_1_join,_2_join_rows,_random-16    	    2840	    382173 ns/op	  229186 B/op	    5572 allocs/op
BenchmarkDataFrame_OuterJoin/100_rows_-_100_rows,_1_to_1_join,_random-16               	    1971	    587741 ns/op	  217322 B/op	    5362 allocs/op
BenchmarkDataFrame_OuterJoin/300_rows_-_300_rows,_1_to_1_join,_random-16               	     322	   3618047 ns/op	  696409 B/op	   15596 allocs/op
BenchmarkDataFrame_OuterJoin/300_rows_-_300_rows,_1_to_1_join,_2_join_rows,_random-16  	     178	   5963814 ns/op	 1416585 B/op	   32735 allocs/op
BenchmarkDataFrame_OuterJoin/900_rows_-_900_rows,_1_to_1_join,_2_join_rows,_random-16  	      27	  44466751 ns/op	 4837021 B/op	   97592 allocs/op
BenchmarkDataFrame_OuterJoin/1000_rows_-_1000_rows,_1_to_1_join,_2_join_rows,_random-16         	      22	  54494459 ns/op	 5067456 B/op	  108392 allocs/op
PASS
ok  	github.com/go-gota/gota/dataframe	13.358s

Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^BenchmarkDataFrame_OuterJoinOptimized$ github.com/go-gota/gota/dataframe

goos: darwin
goarch: amd64
pkg: github.com/go-gota/gota/dataframe
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkDataFrame_OuterJoinOptimized/10_rows_-_10_rows,_1_to_1_join,_2_rows,_random-16         	   20296	     57646 ns/op	   52054 B/op	     440 allocs/op
BenchmarkDataFrame_OuterJoinOptimized/10_rows_-_10_rows,_1_to_2_join,_2_rows,_random-16         	   21481	     56722 ns/op	   52045 B/op	     436 allocs/op
BenchmarkDataFrame_OuterJoinOptimized/50_rows_-_50_rows,_1_to_1_join,_random-16                 	   10000	    112319 ns/op	  107449 B/op	     761 allocs/op
BenchmarkDataFrame_OuterJoinOptimized/50_rows_-_50_rows,_1_to_1_join,_2_join_rows,_random-16    	    5932	    218852 ns/op	  202601 B/op	    1165 allocs/op
BenchmarkDataFrame_OuterJoinOptimized/100_rows_-_100_rows,_1_to_1_join,_random-16               	    5584	    219878 ns/op	  205372 B/op	    1234 allocs/op
BenchmarkDataFrame_OuterJoinOptimized/300_rows_-_300_rows,_1_to_1_join,_random-16               	    1978	    583060 ns/op	  666228 B/op	    3259 allocs/op
BenchmarkDataFrame_OuterJoinOptimized/300_rows_-_300_rows,_1_to_1_join,_2_join_rows,_random-16  	    1197	   1044144 ns/op	 1233145 B/op	    5847 allocs/op
BenchmarkDataFrame_OuterJoinOptimized/900_rows_-_900_rows,_1_to_1_join,_2_join_rows,_random-16  	     352	   3878439 ns/op	 4567483 B/op	   20935 allocs/op
BenchmarkDataFrame_OuterJoinOptimized/1000_rows_-_1000_rows,_1_to_1_join,_2_join_rows,_random-16         	     325	   3817070 ns/op	 4594584 B/op	   23436 allocs/op
PASS
ok  	github.com/go-gota/gota/dataframe	13.536s



# Summary
For 10x10 rows the previous implementation and the optimized one having comparable performance, but when we use 50 rows or above the optimized implementation way faster compare to the previous.
For 50x50 rows the optimized on almost 2x faster, and it is even better when number of rows increase significantly, for 1000x1000 row the optimized implementation is almost 17x faster
```