### PR TITLE
Change key for column row

### DIFF
--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -1687,9 +1687,17 @@ func (df DataFrame) createRowKey(keys []string, keyIdx []int, rowIdx int) string
 	var sb strings.Builder
 	cols := df.columns
 	for k := range keys {
-		sb.WriteString(cols[keyIdx[k]].Elem(rowIdx).String())
+		val := cols[keyIdx[k]].Elem(rowIdx)
+		sb.WriteString(createValueKey(val))
 	}
 	return sb.String()
+}
+
+func createValueKey(val series.Element) string {
+	if val.Type() == series.Float {
+		return fmt.Sprintf("%g", val.Float())
+	}
+	return val.String()
 }
 
 // InnerJoin returns a DataFrame containing the inner join of two DataFrames.


### PR DESCRIPTION
Previously we rely on String() method of Element interface to convert float to string, but this introduce issue when doing join where the join key type is different between dataframes, e.g left table key is 4 type int, but right table key is 4 type float, it will create different lookup key. For left table the lookup key will be "4" but right table the lookup key will be "4.0000000" hence the join not working properly. This PR aim to fix conversion of whole number float (e.g 4) to string without additional digits