### PR TITLE
Fix conversion of float that used to generate key lookup

### DIFF
--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -1695,7 +1695,7 @@ func (df DataFrame) createRowKey(keys []string, keyIdx []int, rowIdx int) string
 
 func createValueKey(val series.Element) string {
 	if val.Type() == series.Float {
-		return fmt.Sprintf("%g", val.Float())
+		return strconv.FormatFloat(val.Float(), 'f', -1, 64)
 	}
 	return val.String()
 }
@@ -1766,6 +1766,7 @@ func (df DataFrame) LeftJoin(b DataFrame, keys ...string) DataFrame {
 	aCols := df.columns
 	bCols := b.columns
 	bRowIdxLookup := b.createRowIdxLookup(keys, iKeysB)
+	fmt.Println("B row ID Look up ", bRowIdxLookup)
 	numCols := len(iKeysA) + len(iNotKeysA) + len(iNotKeysB)
 	updatedColRows := make(map[int][]series.Element, numCols)
 	for i := 0; i < numCols; i++ {
@@ -1775,6 +1776,7 @@ func (df DataFrame) LeftJoin(b DataFrame, keys ...string) DataFrame {
 	// Fill newCols
 	for i := 0; i < df.nrows; i++ {
 		rowKey := df.createRowKey(keys, iKeysA, i)
+		fmt.Println("A rowKey ", rowKey)
 		bMatchedRowIdxs := bRowIdxLookup[rowKey]
 		if len(bMatchedRowIdxs) == 0 {
 			ii := 0

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -1609,10 +1609,14 @@ func TestDataFrame_InnerJoin(t *testing.T) {
 		},
 	)
 	table := []struct {
-		keys  []string
-		expDf DataFrame
+		leftDataframe  DataFrame
+		rightDataFrame DataFrame
+		keys           []string
+		expDf          DataFrame
 	}{
 		{
+			a,
+			b,
 			[]string{"A", "D"},
 			LoadRecords(
 				[][]string{
@@ -1622,6 +1626,8 @@ func TestDataFrame_InnerJoin(t *testing.T) {
 			),
 		},
 		{
+			a,
+			b,
 			[]string{"A"},
 			LoadRecords(
 				[][]string{
@@ -1633,6 +1639,8 @@ func TestDataFrame_InnerJoin(t *testing.T) {
 			),
 		},
 		{
+			a,
+			b,
 			[]string{"D"},
 			LoadRecords(
 				[][]string{
@@ -1648,9 +1656,69 @@ func TestDataFrame_InnerJoin(t *testing.T) {
 				},
 			),
 		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]string{"1234567.89", "0", "34567890.34"}, series.String, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]float64{1234567.89, 34567890.34}, series.Float, "B"),
+				series.New([]int{1000000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1020.20"}, series.String, "C"),
+				series.New([]interface{}{1.0, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, 1020}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]string{"1234567.89", "0", "34567890.34"}, series.String, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]string{"1234567.89", "34567890.34"}, series.String, "B"),
+				series.New([]int{1000000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1020.20"}, series.String, "C"),
+				series.New([]interface{}{1.0, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, 1020}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]float64{1234567.8900000, 0, 34567890.3400000}, series.Float, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]float64{1234567.8900000, 34567890.3400000}, series.Float, "B"),
+				series.New([]int{1000000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1020.20"}, series.String, "C"),
+				series.New([]interface{}{1.0, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, 1020}, series.Int, "F"),
+			),
+		},
 	}
 	for i, tc := range table {
-		c := a.InnerJoin(b, tc.keys...)
+		c := tc.leftDataframe.InnerJoin(tc.rightDataFrame, tc.keys...)
 
 		if err := c.Err; err != nil {
 			t.Errorf("Test: %d\nError:%v", i, b.Err)
@@ -1693,11 +1761,16 @@ func TestDataFrame_LeftJoin(t *testing.T) {
 		DetectTypes(false),
 		DefaultType(series.Float),
 	)
+
 	table := []struct {
-		keys  []string
-		expDf DataFrame
+		leftDataframe  DataFrame
+		rightDataFrame DataFrame
+		keys           []string
+		expDf          DataFrame
 	}{
 		{
+			a,
+			b,
 			[]string{"A", "D"},
 			LoadRecords(
 				[][]string{
@@ -1712,6 +1785,8 @@ func TestDataFrame_LeftJoin(t *testing.T) {
 			),
 		},
 		{
+			a,
+			b,
 			[]string{"A"},
 			LoadRecords(
 				[][]string{
@@ -1725,9 +1800,69 @@ func TestDataFrame_LeftJoin(t *testing.T) {
 				DefaultType(series.Float),
 			),
 		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]string{"1234567.89", "0", "34567890.34"}, series.String, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, 1020}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]string{"1234567.89", "0", "34567890.34"}, series.String, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]string{"1234567.89", "0", "34567890.34"}, series.String, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, 1020}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]float64{1234567.8900000, 0, 34567890.3400000}, series.Float, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]float64{1234567.8900000, 0, 34567890.3400000}, series.Float, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, 1020}, series.Int, "F"),
+			),
+		},
 	}
 	for i, tc := range table {
-		c := a.LeftJoin(b, tc.keys...)
+		c := tc.leftDataframe.LeftJoin(tc.rightDataFrame, tc.keys...)
 
 		if err := c.Err; err != nil {
 			t.Errorf("Test: %d\nError:%v", i, b.Err)

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -1982,7 +1982,7 @@ func TestDataFrame_LeftJoin(t *testing.T) {
 		},
 		{
 			New(
-				series.New([]interface{}{"1234567.89", "0", nil}, series.String, "B"),
+				series.New([]interface{}{1234567.89, 0, nil}, series.Float, "B"),
 				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
 				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
 			),
@@ -1993,7 +1993,7 @@ func TestDataFrame_LeftJoin(t *testing.T) {
 			),
 			[]string{"B"},
 			New(
-				series.New([]interface{}{"1234567.89", "0", nil}, series.String, "B"),
+				series.New([]interface{}{1234567.89, 0, nil}, series.Float, "B"),
 				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
 				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
 				series.New([]interface{}{1.0, nil, nil}, series.Float, "D"),

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -1659,6 +1659,46 @@ func TestDataFrame_InnerJoin(t *testing.T) {
 		{
 			New(
 				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]float64{1234567, 2345678, 34567890}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]int{1234567, 0, 34567890}, series.Int, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]float64{1234567, 34567890}, series.Float, "B"),
+				series.New([]int{1000000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1020.20"}, series.String, "C"),
+				series.New([]interface{}{1.0, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, 1020}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]float64{1234567, 2345678, 34567890}, series.Int, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]float64{1234567, 0, 34567890}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]int{1234567, 34567890}, series.Int, "B"),
+				series.New([]int{1000000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1020.20"}, series.String, "C"),
+				series.New([]interface{}{1.0, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, 1020}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
 				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
 				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
 			),
@@ -1798,6 +1838,46 @@ func TestDataFrame_LeftJoin(t *testing.T) {
 				},
 				DetectTypes(false),
 				DefaultType(series.Float),
+			),
+		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]float64{1234567, 2345678, 34567890}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]int{1234567, 0, 34567890}, series.Int, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]int{1234567, 2345678, 34567890}, series.Float, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, 1020}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]int{1234567, 2345678, 34567890}, series.Int, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]float64{1234567, 0, 34567890}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]int{1234567, 2345678, 34567890}, series.Int, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, 1020}, series.Int, "F"),
 			),
 		},
 		{
@@ -2006,6 +2086,46 @@ func TestDataFrame_RightJoin(t *testing.T) {
 		{
 			New(
 				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]float64{1234567, 2345678, 34567890}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]int{1234567, 0, 34567890}, series.Int, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]float64{1234567, 34567890, 0}, series.Float, "B"),
+				series.New([]interface{}{1000000000, 900000000, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", "1020.20", nil}, series.String, "C"),
+				series.New([]float64{1.0, 3.0, 2.0}, series.Float, "D"),
+				series.New([]int{1000, 1020, 1010}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]int{1234567, 2345678, 34567890}, series.Int, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]float64{1234567, 0, 34567890}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]int{1234567, 34567890, 0}, series.Int, "B"),
+				series.New([]interface{}{1000000000, 900000000, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", "1020.20", nil}, series.String, "C"),
+				series.New([]float64{1.0, 3.0, 2.0}, series.Float, "D"),
+				series.New([]int{1000, 1020, 1010}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
 				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
 				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
 			),
@@ -2209,6 +2329,46 @@ func TestDataFrame_OuterJoin(t *testing.T) {
 				},
 				DetectTypes(false),
 				DefaultType(series.Float),
+			),
+		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]float64{1234567, 2345678, 34567890}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]int{1234567, 0, 34567890}, series.Int, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]float64{1234567, 2345678, 34567890, 0}, series.Float, "B"),
+				series.New([]interface{}{1000000000, 800000000, 900000000, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", "1010.15", "1020.20", nil}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, 3.0, 2.0}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, 1020, 1010}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]int{1234567, 2345678, 34567890}, series.Int, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]float64{1234567, 0, 34567890}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]int{1234567, 2345678, 34567890, 0}, series.Int, "B"),
+				series.New([]interface{}{1000000000, 800000000, 900000000, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", "1010.15", "1020.20", nil}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, 3.0, 2.0}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, 1020, 1010}, series.Int, "F"),
 			),
 		},
 		{

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -1860,6 +1860,66 @@ func TestDataFrame_LeftJoin(t *testing.T) {
 				series.New([]interface{}{1000, nil, 1020}, series.Int, "F"),
 			),
 		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]interface{}{1234567.89, 2345678.12, nil}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]interface{}{"1234567.89", "0", nil}, series.String, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]interface{}{1234567.89, 2345678.12, nil}, series.Float, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, nil}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, nil}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]interface{}{1234567.89, 2345678.12, 12345.2}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]interface{}{"1234567.89", "0", nil}, series.String, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]interface{}{1234567.89, 2345678.12, 12345.2}, series.Float, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, nil}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, nil}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]interface{}{"1234567.89", "0", nil}, series.String, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]interface{}{1234567.89, 2345678.12, nil}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]interface{}{"1234567.89", "0", nil}, series.String, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, nil}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, nil}, series.Int, "F"),
+			),
+		},
 	}
 	for i, tc := range table {
 		c := tc.leftDataframe.LeftJoin(tc.rightDataFrame, tc.keys...)
@@ -1906,10 +1966,14 @@ func TestDataFrame_RightJoin(t *testing.T) {
 		DefaultType(series.Float),
 	)
 	table := []struct {
-		keys  []string
-		expDf DataFrame
+		leftDataframe  DataFrame
+		rightDataframe DataFrame
+		keys           []string
+		expDf          DataFrame
 	}{
 		{
+			a,
+			b,
 			[]string{"A", "D"},
 			LoadRecords(
 				[][]string{
@@ -1924,6 +1988,8 @@ func TestDataFrame_RightJoin(t *testing.T) {
 			),
 		},
 		{
+			a,
+			b,
 			[]string{"A"},
 			LoadRecords(
 				[][]string{
@@ -1937,9 +2003,129 @@ func TestDataFrame_RightJoin(t *testing.T) {
 				DefaultType(series.Float),
 			),
 		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]string{"1234567.89", "0", "34567890.34"}, series.String, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]string{"1234567.89", "34567890.34", "0"}, series.Float, "B"),
+				series.New([]interface{}{1000000000, 900000000, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", "1020.20", nil}, series.String, "C"),
+				series.New([]float64{1.0, 3.0, 2.0}, series.Float, "D"),
+				series.New([]int{1000, 1020, 1010}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]string{"1234567.89", "0", "34567890.34"}, series.String, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]string{"1234567.890000", "34567890.340000", "2345678.120000"}, series.String, "B"),
+				series.New([]interface{}{1000000000, 900000000, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", "1020.20", nil}, series.String, "C"),
+				series.New([]float64{1.0, 3.0, 2.0}, series.Float, "D"),
+				series.New([]int{1000, 1020, 1010}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]float64{1234567.8900000, 0, 34567890.3400000}, series.Float, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]float64{1234567.8900000, 34567890.3400000, 2345678.12}, series.Float, "B"),
+				series.New([]interface{}{1000000000, 900000000, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", "1020.20", nil}, series.String, "C"),
+				series.New([]float64{1.0, 3.0, 2.0}, series.Float, "D"),
+				series.New([]int{1000, 1020, 1010}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]interface{}{1234567.89, 2345678.12, nil}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]interface{}{"1234567.89", "0", nil}, series.String, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]interface{}{1234567.89, 0, nil}, series.Float, "B"),
+				series.New([]interface{}{1000000000, nil, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", nil, nil}, series.String, "C"),
+				series.New([]interface{}{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, 1010, 1020}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]interface{}{1234567.89, 2345678.12, 12345.2}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]interface{}{"1234567.89", "0", nil}, series.String, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]interface{}{1234567.89, 0, nil}, series.Float, "B"),
+				series.New([]interface{}{1000000000, nil, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", nil, nil}, series.String, "C"),
+				series.New([]interface{}{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, 1010, 1020}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]interface{}{"1234567.89", "0", nil}, series.String, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]interface{}{1234567.89, 2345678.12, nil}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]interface{}{"1234567.890000", "2345678.120000", nil}, series.String, "B"),
+				series.New([]interface{}{1000000000, nil, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", nil, nil}, series.String, "C"),
+				series.New([]interface{}{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, 1010, 1020}, series.Int, "F"),
+			),
+		},
 	}
 	for i, tc := range table {
-		c := a.RightJoin(b, tc.keys...)
+		c := tc.leftDataframe.RightJoin(tc.rightDataframe, tc.keys...)
 
 		if err := c.Err; err != nil {
 			t.Errorf("Test: %d\nError:%v", i, b.Err)
@@ -1983,10 +2169,14 @@ func TestDataFrame_OuterJoin(t *testing.T) {
 		DefaultType(series.Float),
 	)
 	table := []struct {
-		keys  []string
-		expDf DataFrame
+		leftDataframe  DataFrame
+		rightDataframe DataFrame
+		keys           []string
+		expDf          DataFrame
 	}{
 		{
+			a,
+			b,
 			[]string{"A", "D"},
 			LoadRecords(
 				[][]string{
@@ -2004,6 +2194,8 @@ func TestDataFrame_OuterJoin(t *testing.T) {
 			),
 		},
 		{
+			a,
+			b,
 			[]string{"A"},
 			LoadRecords(
 				[][]string{
@@ -2019,9 +2211,109 @@ func TestDataFrame_OuterJoin(t *testing.T) {
 				DefaultType(series.Float),
 			),
 		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]string{"1234567.89", "0", "34567890.34"}, series.String, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34, 0}, series.Float, "B"),
+				series.New([]interface{}{1000000000, 800000000, 900000000, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", "1010.15", "1020.20", nil}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, 3.0, 2.0}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, 1020, 1010}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]string{"1234567.89", "0", "34567890.34"}, series.String, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]string{"1234567.89", "0", "34567890.34", "2345678.120000"}, series.String, "B"),
+				series.New([]interface{}{1000000000, 800000000, 900000000, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", "1010.15", "1020.20", nil}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, 3.0, 2.0}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, 1020, 1010}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]float64{1234567.8900000, 0, 34567890.3400000}, series.Float, "B"),
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]float64{1234567.89, 2345678.12, 34567890.34}, series.Float, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]float64{1234567.8900000, 0, 34567890.3400000, 2345678.12}, series.Float, "B"),
+				series.New([]interface{}{1000000000, 800000000, 900000000, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", "1010.15", "1020.20", nil}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, 3.0, 2.0}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, 1020, 1010}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]interface{}{1234567.89, 2345678.12, nil}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]interface{}{"1234567.89", "0", nil}, series.String, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]interface{}{1234567.89, 2345678.12, nil, 0, nil}, series.Float, "B"),
+				series.New([]interface{}{1000000000, 800000000, 900000000, nil, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", "1010.15", "1020.20", nil, nil}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, nil, 2.0, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, nil, 1010, 1020}, series.Int, "F"),
+			),
+		},
+		{
+			New(
+				series.New([]int{1000000000, 800000000, 900000000}, series.Int, "A"),
+				series.New([]interface{}{1234567.89, 2345678.12, 12345.2}, series.Float, "B"),
+				series.New([]string{"1000", "1010.15", "1020.20"}, series.String, "C"),
+			),
+			New(
+				series.New([]interface{}{"1234567.89", "0", nil}, series.String, "B"),
+				series.New([]float64{1.0, 2.0, 3.0}, series.Float, "D"),
+				series.New([]int{1000, 1010, 1020}, series.Int, "F"),
+			),
+			[]string{"B"},
+			New(
+				series.New([]interface{}{1234567.89, 2345678.12, 12345.2, 0, nil}, series.Float, "B"),
+				series.New([]interface{}{1000000000, 800000000, 900000000, nil, nil}, series.Int, "A"),
+				series.New([]interface{}{"1000", "1010.15", "1020.20", nil, nil}, series.String, "C"),
+				series.New([]interface{}{1.0, nil, nil, 2.0, 3.0}, series.Float, "D"),
+				series.New([]interface{}{1000, nil, nil, 1010, 1020}, series.Int, "F"),
+			),
+		},
 	}
 	for i, tc := range table {
-		c := a.OuterJoin(b, tc.keys...)
+		c := tc.leftDataframe.OuterJoin(tc.rightDataframe, tc.keys...)
 
 		if err := c.Err; err != nil {
 			t.Errorf("Test: %d\nError:%v", i, b.Err)

--- a/series/type-float.go
+++ b/series/type-float.go
@@ -46,8 +46,10 @@ func (e *floatElement) Set(value interface{}) {
 			e.e = 0
 		}
 	case Element:
-		e.e = val.Float()
 		e.nan = val.IsNA()
+		if !e.nan {
+			e.e = val.Float()
+		}
 	default:
 		e.nan = true
 		return


### PR DESCRIPTION
When improving performance of join, we use hash join approach where we convert all the value for join keys column into string. Issue is raised when join column type is float64 and the way we do conversion is by using `%g` formatting which will use exponent when necessary, and the join column type in another table is in int type. For example
```
join_column_left_tbl -> 900000000 (int type) -> convert to string -> 900000000
join_column_right_tbl -> 900000000(float type) -> convert to string -> 9e+08
```
the generated keys is different hence the join is not working properly. The solution is to change the conversion to not use exponent